### PR TITLE
chore: Remove common- beanutils and spring-webmvc dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ plexusUtils="4.0.1"
 sonarqube = "5.1.0.4882"
 springBoot = "3.3.4"
 springDoc = "2.6.0"
-springWebMvc = "6.1.13"
 wsdl4j = "1.6.3"
 wsdl2java = "2.0.2"
 xroadLibs = "7.6.0-SNAPSHOT"
@@ -58,7 +57,6 @@ spring-boot-jpa = { module = "org.springframework.boot:spring-boot-starter-data-
 spring-boot-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBoot" }
 spring-boot-ws = { module = "org.springframework.boot:spring-boot-starter-web-services", version.ref = "springBoot" }
 spring-doc = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springDoc" }
-spring-webmvc = { module = "org.springframework:spring-webmvc", version.ref = "springWebMvc" }
 wsdl4j = { module = "wsdl4j:wsdl4j", version.ref = "wsdl4j" }
 xmlunit-core = { module = "org.xmlunit:xmlunit-core", version = "2.10.0" }
 xroad-configuration-client = { module = "org.niis.xroad:configuration-client", version.ref = "xroadLibs" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 awaitility = "4.2.2"
-commonsBeanutils = "1.9.4"
 commonsCompress = "1.27.1"
 commonsCsv = "1.11.0"
 cxf = "4.0.5"
@@ -30,7 +29,6 @@ xroadLibs = "7.6.0-SNAPSHOT"
 
 [libraries]
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
-commons-bean-utils = { module = "commons-beanutils:commons-beanutils", version.ref = "commonsBeanutils" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commonsCompress" }
 commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "commonsCsv" }
 cxf-core = { module = "org.apache.cxf:cxf-core", version.ref = "cxf" }

--- a/xroad-catalog-collector/build.gradle
+++ b/xroad-catalog-collector/build.gradle
@@ -85,7 +85,6 @@ dependencies {
     implementation (libs.json)
     implementation (libs.spring.boot.ws)
     implementation (libs.spring.boot.jpa)
-    implementation (libs.spring.webmvc)
     implementation (libs.jackson)
     // Note that bundle seems to break something with CXF and being able top find api bindings, so using separate dependencies here
     implementation (libs.cxf.jaxws)

--- a/xroad-catalog-lister/build.gradle
+++ b/xroad-catalog-lister/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation (libs.spring.webmvc)
     implementation (libs.jackson)
     implementation (libs.wsdl4j)
-    implementation (libs.commons.bean.utils)
     implementation (libs.guava)
     implementation (libs.lombok)
     implementation (libs.xmlunit.core)

--- a/xroad-catalog-lister/build.gradle
+++ b/xroad-catalog-lister/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     implementation (libs.commons.csv)
     implementation (libs.spring.boot.ws)
     implementation (libs.spring.boot.jpa)
-    implementation (libs.spring.webmvc)
     implementation (libs.jackson)
     implementation (libs.wsdl4j)
     implementation (libs.guava)

--- a/xroad-catalog-lister/src/test/java/fi/dvv/xroad/catalog/lister/service/JaxbCatalogServiceTest.java
+++ b/xroad-catalog-lister/src/test/java/fi/dvv/xroad/catalog/lister/service/JaxbCatalogServiceTest.java
@@ -13,7 +13,6 @@
 package fi.dvv.xroad.catalog.lister.service;
 
 import com.google.common.collect.Iterables;
-import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -26,6 +25,7 @@ import org.niis.xroad.catalog.persistence.entity.Member;
 import org.niis.xroad.catalog.persistence.entity.Service;
 import org.niis.xroad.catalog.persistence.entity.Subsystem;
 import org.niis.xroad.catalog.persistence.entity.Wsdl;
+import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -149,8 +149,7 @@ public class JaxbCatalogServiceTest {
         assertNotNull(s223.getRemoved());
     }
 
-    private <T> Collection<String> getPropertyValues(Iterable<T> items, String propertyName) throws IllegalAccessException,
-            NoSuchMethodException, InvocationTargetException {
+    private <T> Collection<String> getPropertyValues(Iterable<T> items, String propertyName) {
         List<String> values = new ArrayList<>();
         for (Object item : items) {
             values.add(getStringProperty(propertyName, item));
@@ -158,13 +157,11 @@ public class JaxbCatalogServiceTest {
         return values;
     }
 
-    private String getStringProperty(String propertyName, Object item) throws IllegalAccessException,
-            InvocationTargetException, NoSuchMethodException {
-        return (String) PropertyUtils.getProperty(item, propertyName);
+    private String getStringProperty(String propertyName, Object item) {
+        return (String) PropertyAccessorFactory.forBeanPropertyAccess(item).getPropertyValue(propertyName);
     }
 
-    private <T> T getItem(Iterable<T> items, String propertyName, String value) throws IllegalAccessException,
-            NoSuchMethodException, InvocationTargetException {
+    private <T> T getItem(Iterable<T> items, String propertyName, String value) {
         for (T item : items) {
             if (value.equals(getStringProperty(propertyName, item))) {
                 return item;
@@ -173,19 +170,16 @@ public class JaxbCatalogServiceTest {
         return null;
     }
 
-    private Collection<String> getMemberCodes(Iterable<org.niis.xroad.catalog.lister.generated.Member> members)
-            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    private Collection<String> getMemberCodes(Iterable<org.niis.xroad.catalog.lister.generated.Member> members) {
         return getPropertyValues(members, PROPERTY_MEMBER_CODE);
     }
 
     private Collection<String> getSubsystemCodes(
-            Iterable<org.niis.xroad.catalog.lister.generated.Subsystem> subsystems)
-            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+            Iterable<org.niis.xroad.catalog.lister.generated.Subsystem> subsystems) {
         return getPropertyValues(subsystems, PROPERTY_SUBSYSTEM_CODE);
     }
 
-    private Collection<String> getServiceCodes(Iterable<org.niis.xroad.catalog.lister.generated.Service> services)
-            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    private Collection<String> getServiceCodes(Iterable<org.niis.xroad.catalog.lister.generated.Service> services) {
         return getPropertyValues(services, PROPERTY_SERVICE_CODE);
     }
 


### PR DESCRIPTION
* Replacing commons-beanutils usage with spring boot class to remove it from dependencies
* Spring-WebMVC dependency was added to fix security issue. Latest Spring Boot (v.3.3.4) is using the same version by default (so no need to explicitly declare it)

Refs: XRDCAT-28