### PR TITLE
chore: publish docker images to github's registry

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -31,8 +31,6 @@ jobs:
           add-job-summary-as-pr-comment: always
       - name: Build JARs (skipping tests)
         run: ./gradlew --no-daemon build -x test
-      - name: print working directory
-        run: pwd
       - name: List JAR files
         run: ls -lah xroad-catalog-collector/build/libs xroad-catalog-lister/build/libs
       - name: Log in to the Container registry

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -10,12 +10,9 @@ env:
   XROAD_HOME: ${{ github.workspace }}
 jobs:
   BuildAndPublish:
-    name: Setup Environment
+    name: Build and publish docker images
     #if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        service: [collector, listener]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -38,24 +35,49 @@ jobs:
       - name: print working directory
         run: pwd
       - name: List JAR files
-        run: ls -lah xroad-catalog-${{ matrix.service }}/build/libs
+        run: ls -lah xroad-catalog-collector/build/libs xroad-catalog-lister/build/libs
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push xrddev-catalog-${{ matrix.service }}'s Docker Image
+      - name: Build and push xrddev-catalog-collector's Docker Image
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
-          file: ${{ github.workspace }}/docker/${{ matrix.service }}/Dockerfile
+          file: ${{ github.workspace }}/docker/collector/Dockerfile
           push: true
-          tags: ghcr.io/nordic-institute/xrddev-catalog-${{ matrix.service }}:latest
-      - name: Clean old ${{ matrix.service }} images
+          tags: ghcr.io/nordic-institute/xrddev-catalog-collector:latest
+      - name: Build and push xrddev-catalog-lister's Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          file: ${{ github.workspace }}/docker/lister/Dockerfile
+          push: true
+          tags: ghcr.io/nordic-institute/xrddev-catalog-lister:latest
+
+  CleanOldImages:
+    name: Build and publish docker images
+    if: ${{ needs.BuildAndPublish.result == 'success' }}
+    needs: BuildAndPublish
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clean old xrddev-catalog-collector's Docker Images
         uses: snok/container-retention-policy@v2
         with:
-          image-names: xrddev-catalog-${{ matrix.service }}
+          image-names: xrddev-catalog-collector
+          cut-off: 1 week ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: nordic-institute
+          keep-at-least: 1
+          token-type: github-token
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean old xrddev-catalog-lister's Docker Images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: xrddev-catalog-lister
           cut-off: 1 week ago UTC
           timestamp-to-use: created_at
           account-type: org

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
-          file: ${{ github.workspace }}/docker/${{ matrix.service }}
+          file: ${{ github.workspace }}/docker/${{ matrix.service }}/Dockerfile
           push: true
           tags: ghcr.io/nordic-institute/xrddev-catalog-${{ matrix.service }}:latest
       - name: Clean old ${{ matrix.service }} images

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,17 +1,17 @@
 name: Publish images
 on:
-  workflow_run:
-    workflows: ["X-Road-Catalog tests"]
-    types: [completed]
-    branches: [develop, XRDCAT-28-**]
-  workflow_dispatch: {}
+  workflow_dispatch:
+#  workflow_run:
+#    workflows: ["X-Road-Catalog tests"]
+#    types: [completed]
+#    branches: [develop, XRDCAT-28-**]
 env:
   REGISTRY: ghcr.io
   XROAD_HOME: ${{ github.workspace }}
 jobs:
   BuildAndPublish:
     name: Setup Environment
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        service: [collector]
+        service: [collector, listener]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        service: [collector, lister]
+        service: [collector]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -7,7 +7,6 @@ on:
 #    branches: [develop, XRDCAT-28-**]
 env:
   REGISTRY: ghcr.io
-  XROAD_HOME: ${{ github.workspace }}
 jobs:
   BuildAndPublish:
     name: Build and publish docker images

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -63,24 +63,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clean old xrddev-catalog-collector's Docker Images
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@v3.0.0
         with:
+          account: nordic-institute
           image-names: xrddev-catalog-collector
           cut-off: 1 week ago UTC
           timestamp-to-use: created_at
-          account-type: org
-          org-name: nordic-institute
-          keep-at-least: 1
-          token-type: github-token
+          keep-n-most-recent: 1
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Clean old xrddev-catalog-lister's Docker Images
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@v3.0.0
         with:
+          account: nordic-institute
           image-names: xrddev-catalog-lister
           cut-off: 1 week ago UTC
           timestamp-to-use: created_at
-          account-type: org
-          org-name: nordic-institute
-          keep-at-least: 1
-          token-type: github-token
+          keep-n-most-recent: 1
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -35,6 +35,10 @@ jobs:
           add-job-summary-as-pr-comment: always
       - name: Build JARs (skipping tests)
         run: ./gradlew --no-daemon build -x test
+      - name: print working directory
+        run: pwd
+      - name: List JAR files
+        run: ls -lah xroad-catalog-${{ matrix.service }}/build/libs
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           account: nordic-institute
           image-names: xrddev-catalog-collector
-          cut-off: 1 week ago UTC
+          cut-off: 1w
           timestamp-to-use: created_at
           keep-n-most-recent: 1
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
         with:
           account: nordic-institute
           image-names: xrddev-catalog-lister
-          cut-off: 1 week ago UTC
+          cut-off: 1w
           timestamp-to-use: created_at
           keep-n-most-recent: 1
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,16 +1,16 @@
 name: Publish images
 on:
   workflow_dispatch:
-#  workflow_run:
-#    workflows: ["X-Road-Catalog tests"]
-#    types: [completed]
-#    branches: [develop, XRDCAT-28-**]
+  workflow_run:
+    workflows: ["X-Road-Catalog tests"]
+    types: [completed]
+    branches: [develop]
 env:
   REGISTRY: ghcr.io
 jobs:
   BuildAndPublish:
     name: Build and publish docker images
-    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -58,7 +58,7 @@ jobs:
           tags: ghcr.io/nordic-institute/xrddev-catalog-lister:latest
 
   CleanOldImages:
-    name: Build and publish docker images
+    name: Clean old docker images
     if: ${{ needs.BuildAndPublish.result == 'success' }}
     needs: BuildAndPublish
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -48,7 +48,8 @@ jobs:
       - name: Build and push xrddev-catalog-${{ matrix.service }}'s Docker Image
         uses: docker/build-push-action@v6
         with:
-          context: ${{ github.workspace }}/docker/${{ matrix.service }}
+          context: ${{ github.workspace }}
+          file: ${{ github.workspace }}/docker/${{ matrix.service }}
           push: true
           tags: ghcr.io/nordic-institute/xrddev-catalog-${{ matrix.service }}:latest
       - name: Clean old ${{ matrix.service }} images

--- a/docker/collector/Dockerfile
+++ b/docker/collector/Dockerfile
@@ -1,5 +1,5 @@
 # Base image for X-Road Catalog
-FROM eclipse-temurin:21-jre AS base-xroad-catalog
+FROM eclipse-temurin:21-jre-alpine AS base-xroad-catalog
 
 # Labels following the OCI Image Spec
 LABEL org.opencontainers.image.vendor="Nordic Institute for Interoperability Solutions (NIIS)" \

--- a/docker/collector/Dockerfile
+++ b/docker/collector/Dockerfile
@@ -1,5 +1,5 @@
 # Base image for X-Road Catalog
-FROM eclipse-temurin:21-jre-alpine AS base-xroad-catalog
+FROM eclipse-temurin:21-jre AS base-xroad-catalog
 
 # Labels following the OCI Image Spec
 LABEL org.opencontainers.image.vendor="Nordic Institute for Interoperability Solutions (NIIS)" \


### PR DESCRIPTION
Refs: XRDCAT-28

_Notes:_
* The flow can now be triggered either:
  *  manually from [here](https://github.com/nordic-institute/x-road-catalog/actions/workflows/publish_images.yaml)
  * or automatically after a successful build and test from develop
* This action's fix (in this PR) have been used to generate [these packages](https://github.com/orgs/nordic-institute/packages?repo_name=x-road-catalog)