### PR TITLE
chore: Trigger run_tests action automatically by default (excluding files: .md, .gitignore, and images)

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,26 +6,20 @@ on:
   push:
     branches:
       - develop
-    paths:
-      - 'xroad-catalog-collector/src/**'
-      - 'xroad-catalog-lister/src/**'
-      - 'xroad-catalog-persistence/src/**'
-      - '.github/**'
-      - 'gradle/**' # So that gradle changes are tested
-      - 'settings.gradle' # So that gradle changes are tested
-      - 'build.gradle' # So that gradle changes are tested
-      - 'gradle.properties' # So that gradle changes are tested
+    paths-ignore:
+      - '**/3RD-PARTY-NOTICES.txt'
+      - '**/*.md'
+      - '**/.gitignore'
+      - '**/.ort.yml'
+      - 'img/**'
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'xroad-catalog-collector/src/**'
-      - 'xroad-catalog-lister/src/**'
-      - 'xroad-catalog-persistence/src/**'
-      - '.github/**'
-      - 'gradle/**' # So that gradle changes are tested
-      - 'settings.gradle' # So that gradle changes are tested
-      - 'build.gradle' # So that gradle changes are tested
-      - 'gradle.properties' # So that gradle changes are tested
+    paths-ignore:
+      - '**/3RD-PARTY-NOTICES.txt'
+      - '**/*.md'
+      - '**/.gitignore'
+      - '**/.ort.yml'
+      - 'img/**'
 
 permissions:
   contents: write # Required for https://github.com/gradle/actions/tree/main/setup-gradle#github-dependency-graph-support


### PR DESCRIPTION
The objective is to switch triggering the github action from including specific paths to include everything by default and excluding specific files. This is to allow running builds automatically when necessary.

Excluded files are:
* `3RD-PARTY-NOTICES.txt`
* documentation (`*.md` files)
* `.gitignore` files
* `**/.ort.yml' file
* images (`img/**`)